### PR TITLE
Fix tenant auth and semester flows for SaaS compatibility

### DIFF
--- a/frontend/src/lib/runtime-env.ts
+++ b/frontend/src/lib/runtime-env.ts
@@ -60,7 +60,7 @@ const getTenantRealmFromHost = (baseDomain: string): string | null => {
 
   const hostname = window.location.hostname.toLowerCase();
 
-  if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost')) {
+  if (!hostname || hostname === 'localhost') {
     return null;
   }
 

--- a/frontend/src/pages/api/rooms/[id].ts
+++ b/frontend/src/pages/api/rooms/[id].ts
@@ -4,6 +4,8 @@ import { getApiBaseUrl } from '@/lib/runtime-env';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const API_BASE_URL = getApiBaseUrl();
   const { id } = req.query;
+  const forwardedHost = req.headers.host;
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
   
   // Get token from Authorization header
   const authHeader = req.headers.authorization;
@@ -16,7 +18,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   else {
     requestHeaders = {
         'Authorization': authHeader,
+        'X-Forwarded-Host': forwardedHost ?? '',
+        'X-Forwarded-Proto': forwardedProto,
         'Content-Type': 'application/json',
+    };
+  }
+
+  if ((!authHeader || !authHeader.startsWith('Bearer ')) && forwardedHost) {
+    requestHeaders = {
+      ...requestHeaders,
+      'X-Forwarded-Host': forwardedHost,
+      'X-Forwarded-Proto': forwardedProto,
     };
   }
 

--- a/frontend/src/pages/api/rooms/index.ts
+++ b/frontend/src/pages/api/rooms/index.ts
@@ -3,6 +3,8 @@ import { getApiBaseUrl } from '@/lib/runtime-env';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const API_BASE_URL = getApiBaseUrl();
+  const forwardedHost = req.headers.host;
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
   
   // Get token from Authorization header
   const authHeader = req.headers.authorization;
@@ -15,7 +17,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   else {
     requestHeaders = {
         'Authorization': authHeader,
+        'X-Forwarded-Host': forwardedHost ?? '',
+        'X-Forwarded-Proto': forwardedProto,
         'Content-Type': 'application/json',
+    };
+  }
+
+  if ((!authHeader || !authHeader.startsWith('Bearer ')) && forwardedHost) {
+    requestHeaders = {
+      ...requestHeaders,
+      'X-Forwarded-Host': forwardedHost,
+      'X-Forwarded-Proto': forwardedProto,
     };
   }
 

--- a/frontend/src/pages/api/semesters/[id].ts
+++ b/frontend/src/pages/api/semesters/[id].ts
@@ -4,6 +4,8 @@ import { getApiBaseUrl } from '@/lib/runtime-env';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const API_BASE_URL = getApiBaseUrl();
   const { id } = req.query;
+  const forwardedHost = req.headers.host;
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
   
   // Get token from Authorization header
   const authHeader = req.headers.authorization;
@@ -16,7 +18,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   else {
     requestHeaders = {
         'Authorization': authHeader,
+        'X-Forwarded-Host': forwardedHost ?? '',
+        'X-Forwarded-Proto': forwardedProto,
         'Content-Type': 'application/json',
+    };
+  }
+
+  if ((!authHeader || !authHeader.startsWith('Bearer ')) && forwardedHost) {
+    requestHeaders = {
+      ...requestHeaders,
+      'X-Forwarded-Host': forwardedHost,
+      'X-Forwarded-Proto': forwardedProto,
     };
   }
 

--- a/frontend/src/pages/api/semesters/active.ts
+++ b/frontend/src/pages/api/semesters/active.ts
@@ -3,6 +3,8 @@ import { getApiBaseUrl } from '@/lib/runtime-env';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const API_BASE_URL = getApiBaseUrl();
+  const forwardedHost = req.headers.host;
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
   
   // Get token from Authorization header
   const authHeader = req.headers.authorization;
@@ -15,7 +17,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   else {
     requestHeaders = {
         'Authorization': authHeader,
+        'X-Forwarded-Host': forwardedHost ?? '',
+        'X-Forwarded-Proto': forwardedProto,
         'Content-Type': 'application/json',
+    };
+  }
+
+  if ((!authHeader || !authHeader.startsWith('Bearer ')) && forwardedHost) {
+    requestHeaders = {
+      ...requestHeaders,
+      'X-Forwarded-Host': forwardedHost,
+      'X-Forwarded-Proto': forwardedProto,
     };
   }
 

--- a/frontend/src/pages/api/semesters/index.ts
+++ b/frontend/src/pages/api/semesters/index.ts
@@ -3,9 +3,18 @@ import { getApiBaseUrl } from '@/lib/runtime-env';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const API_BASE_URL = getApiBaseUrl();
+  const forwardedHost = req.headers.host;
+  const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
   
   // Get token from Authorization header
   const authHeader = req.headers.authorization;
+
+  if (req.method !== 'GET' && (!authHeader || !authHeader.startsWith('Bearer '))) {
+    return res.status(401).json({
+      message: 'Proxy missing Authorization header'
+    });
+  }
+
   let requestHeaders;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     requestHeaders = {
@@ -15,7 +24,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   else {
     requestHeaders = {
         'Authorization': authHeader,
+        'X-Forwarded-Host': forwardedHost ?? '',
+        'X-Forwarded-Proto': forwardedProto,
         'Content-Type': 'application/json',
+    };
+  }
+
+  if ((!authHeader || !authHeader.startsWith('Bearer ')) && forwardedHost) {
+    requestHeaders = {
+      ...requestHeaders,
+      'X-Forwarded-Host': forwardedHost,
+      'X-Forwarded-Proto': forwardedProto,
     };
   }
 

--- a/frontend/src/pages/semesters.tsx
+++ b/frontend/src/pages/semesters.tsx
@@ -36,6 +36,11 @@ interface CreateSemesterDto {
   isActive: boolean;
 }
 
+interface ApiErrorResponse {
+  message?: string;
+  debug?: string;
+}
+
 export default function SemestersPage() {
   const { user } = useAuth();
   const [semesters, setSemesters] = useState<Semester[]>([]);
@@ -53,39 +58,14 @@ export default function SemestersPage() {
     isActive: false
   });
   const [submitting, setSubmitting] = useState(false);
-  const [debugClaims, setDebugClaims] = useState<any>(null);
 
   const isAdmin = user?.roles.includes('Administrator');
 
   useEffect(() => {
     if (isAdmin) {
       fetchSemesters();
-      // Debug: fetch claims to see what's happening
-      debugFetchClaims();
     }
   }, [isAdmin]);
-
-  const debugFetchClaims = async () => {
-    try {
-      const token = localStorage.getItem('accessToken');
-      if (!token) return;
-
-      const response = await fetch('/api/debug/claims', {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.ok) {
-        const claims = await response.json();
-        setDebugClaims(claims);
-        console.log('Debug Claims:', claims);
-      }
-    } catch (err) {
-      console.error('Error fetching debug claims:', err);
-    }
-  };
 
   const fetchSemesters = async () => {
     try {
@@ -212,7 +192,12 @@ export default function SemestersPage() {
       }
 
       if (!response.ok) {
-        throw new Error('Failed to save semester');
+        const errorPayload = await readApiError(response);
+        const details = [errorPayload.message, errorPayload.debug]
+          .filter((value): value is string => Boolean(value && value.trim()))
+          .join(' | ');
+
+        throw new Error(details || 'Failed to save semester');
       }
 
       await fetchSemesters();
@@ -602,4 +587,30 @@ export default function SemestersPage() {
       </main>
     </ProtectedRoute>
   );
+}
+
+async function readApiError(response: Response): Promise<ApiErrorResponse> {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch {
+      return {
+        message: `Backend error: ${response.status} ${response.statusText}`
+      };
+    }
+  }
+
+  try {
+    const text = await response.text();
+    return {
+      message: `Backend error: ${response.status} ${response.statusText}`,
+      debug: text.slice(0, 200)
+    };
+  } catch {
+    return {
+      message: `Backend error: ${response.status} ${response.statusText}`
+    };
+  }
 }

--- a/src/StudentRegistrar.Api/Program.cs
+++ b/src/StudentRegistrar.Api/Program.cs
@@ -11,8 +11,11 @@ using System.Text;
 using AutoMapper;
 using StudentRegistrar.Api.DTOs;
 using Npgsql.EntityFrameworkCore.PostgreSQL;
+using System.Collections.Concurrent;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
+var httpContextAccessor = new HttpContextAccessor();
 
 var allowUntrustedKeycloakCertificates =
     builder.Configuration.GetValue<bool?>("Keycloak:AllowUntrustedCertificates")
@@ -20,6 +23,7 @@ var allowUntrustedKeycloakCertificates =
 
 // Add service defaults & Aspire components
 builder.AddServiceDefaults();
+builder.Services.AddSingleton<IHttpContextAccessor>(httpContextAccessor);
 
 // Add tenant services for multi-tenancy support
 builder.Services.AddTenantServices();
@@ -105,8 +109,9 @@ builder.Services.AddCors(options =>
             ?? Array.Empty<string>();
         var defaultOrigins = new[] { "http://localhost:3000", "http://localhost:3001" };
         var allowedOrigins = configuredOrigins.Length > 0 ? configuredOrigins : defaultOrigins;
+        var baseDomain = builder.Configuration["Tenancy:BaseDomain"] ?? "ruffregistrar.com";
 
-        policy.WithOrigins(allowedOrigins)
+        policy.SetIsOriginAllowed(origin => IsAllowedCorsOrigin(origin, allowedOrigins, baseDomain))
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();
@@ -120,18 +125,15 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         var realm = builder.Configuration["Keycloak:Realm"] ?? "student-registrar";
         var clientId = builder.Configuration["Keycloak:ClientId"] ?? "student-registrar";
         var publicClientId = builder.Configuration["Keycloak:PublicClientId"] ?? "student-registrar-spa";
-        var authority = builder.Configuration["Keycloak:Authority"];
-        if (string.IsNullOrWhiteSpace(authority))
+        var authorityBaseUrl = builder.Configuration["Keycloak:Authority"];
+        if (string.IsNullOrWhiteSpace(authorityBaseUrl))
         {
             var keycloakUrl = builder.Configuration.GetConnectionString("keycloak") ?? "http://localhost:8080";
-            authority = keycloakUrl;
+            authorityBaseUrl = keycloakUrl;
         }
 
-        authority = authority!.TrimEnd('/');
-        if (!authority.Contains("/realms/", StringComparison.OrdinalIgnoreCase))
-        {
-            authority = $"{authority}/realms/{realm}";
-        }
+        authorityBaseUrl = authorityBaseUrl!.TrimEnd('/');
+        var authority = BuildRealmAuthority(authorityBaseUrl, realm);
 
         options.Authority = authority;
         options.Audience = clientId;
@@ -152,7 +154,23 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidAudiences = new[] { clientId, publicClientId, "account" }, // Accept configured audiences
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
-            ClockSkew = TimeSpan.Zero
+            ClockSkew = TimeSpan.Zero,
+            IssuerSigningKeyResolver = (_, _, keyId, _) =>
+            {
+                var expectedIssuer = ResolveExpectedIssuer(httpContextAccessor.HttpContext, authorityBaseUrl, realm);
+                return ResolveSigningKeys(expectedIssuer, keyId, allowUntrustedKeycloakCertificates);
+            },
+            IssuerValidator = (issuer, _, _) =>
+            {
+                var expectedIssuer = ResolveExpectedIssuer(httpContextAccessor.HttpContext, authorityBaseUrl, realm);
+
+                if (!string.Equals(NormalizeIssuer(issuer), NormalizeIssuer(expectedIssuer), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new SecurityTokenInvalidIssuerException($"IDX10205: Issuer validation failed. Issuer: '{issuer}'. Expected: '{expectedIssuer}'.");
+                }
+
+                return issuer;
+            }
         };
         
         // Configure JWT token handling for Keycloak roles
@@ -295,3 +313,118 @@ app.MapControllers();
 app.MapDefaultEndpoints();
 
 await app.RunAsync();
+
+static string ResolveExpectedIssuer(HttpContext? httpContext, string authorityBaseUrl, string defaultRealm)
+{
+    var tenantContextAccessor = httpContext?.RequestServices.GetService<ITenantContextAccessor>();
+    var tenantRealm = tenantContextAccessor?.TenantContext?.Tenant?.KeycloakRealm;
+    var realm = string.IsNullOrWhiteSpace(tenantRealm) ? defaultRealm : tenantRealm;
+
+    return BuildRealmAuthority(authorityBaseUrl, realm);
+}
+
+static string BuildRealmAuthority(string authorityBaseUrl, string realm)
+{
+    var normalizedAuthority = authorityBaseUrl.TrimEnd('/');
+    var realmsSegment = "/realms/";
+    var realmIndex = normalizedAuthority.IndexOf(realmsSegment, StringComparison.OrdinalIgnoreCase);
+
+    if (realmIndex >= 0)
+    {
+        normalizedAuthority = normalizedAuthority[..realmIndex];
+    }
+
+    return $"{normalizedAuthority}{realmsSegment}{realm}";
+}
+
+static string NormalizeIssuer(string issuer)
+{
+    return issuer.TrimEnd('/');
+}
+
+static bool IsAllowedCorsOrigin(string origin, IReadOnlyCollection<string> allowedOrigins, string baseDomain)
+{
+    if (allowedOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase))
+    {
+        return true;
+    }
+
+    if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+    {
+        return false;
+    }
+
+    if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    var normalizedBaseDomain = baseDomain.Trim().ToLowerInvariant();
+    var host = uri.Host.ToLowerInvariant();
+
+    if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
+        || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+    {
+        return true;
+    }
+
+    if (string.IsNullOrWhiteSpace(normalizedBaseDomain))
+    {
+        return false;
+    }
+
+    if (string.Equals(host, normalizedBaseDomain, StringComparison.OrdinalIgnoreCase))
+    {
+        return true;
+    }
+
+    return host.EndsWith($".{normalizedBaseDomain}", StringComparison.OrdinalIgnoreCase);
+}
+
+static IReadOnlyCollection<SecurityKey> ResolveSigningKeys(string issuer, string? keyId, bool allowUntrustedCertificates)
+{
+    var normalizedIssuer = NormalizeIssuer(issuer);
+    var cachedKeys = SigningKeyCache.Keys.AddOrUpdate(
+        normalizedIssuer,
+        _ => FetchSigningKeys(normalizedIssuer, allowUntrustedCertificates),
+        (_, existing) => existing.ExpiresAt > DateTimeOffset.UtcNow
+            ? existing
+            : FetchSigningKeys(normalizedIssuer, allowUntrustedCertificates));
+
+    if (string.IsNullOrWhiteSpace(keyId))
+    {
+        return cachedKeys.Keys;
+    }
+
+    var matchingKeys = cachedKeys.Keys.Where(key => string.Equals(key.KeyId, keyId, StringComparison.Ordinal)).ToArray();
+    return matchingKeys.Length > 0 ? matchingKeys : cachedKeys.Keys;
+}
+
+static CachedSigningKeys FetchSigningKeys(string issuer, bool allowUntrustedCertificates)
+{
+    using var handler = new HttpClientHandler();
+    if (allowUntrustedCertificates)
+    {
+        handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+    }
+
+    using var client = new HttpClient(handler);
+    var jwksUrl = $"{NormalizeIssuer(issuer)}/protocol/openid-connect/certs";
+    var response = client.GetAsync(jwksUrl).GetAwaiter().GetResult();
+    response.EnsureSuccessStatusCode();
+
+    var jwksJson = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+    var jwks = new JsonWebKeySet(jwksJson);
+
+    return new CachedSigningKeys(
+        jwks.GetSigningKeys().ToArray(),
+        DateTimeOffset.UtcNow.AddMinutes(10));
+}
+
+file sealed record CachedSigningKeys(IReadOnlyCollection<SecurityKey> Keys, DateTimeOffset ExpiresAt);
+
+file static class SigningKeyCache
+{
+    internal static ConcurrentDictionary<string, CachedSigningKeys> Keys { get; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/StudentRegistrar.Api/Services/Infrastructure/TenantResolutionMiddleware.cs
+++ b/src/StudentRegistrar.Api/Services/Infrastructure/TenantResolutionMiddleware.cs
@@ -79,7 +79,7 @@ public class TenantResolutionMiddleware
         //
         // Controllers using [Authorize] will automatically enforce tenant membership
         // via the "TenantMember" policy configured in TenantAuthorizationHandler.
-        var host = context.Request.Host.Host;
+        var host = GetEffectiveHost(context);
         var subdomain = ExtractSubdomain(host);
 
         if (string.IsNullOrEmpty(subdomain))
@@ -175,6 +175,17 @@ public class TenantResolutionMiddleware
         }
 
         return subdomain;
+    }
+
+    private static string GetEffectiveHost(HttpContext context)
+    {
+        var forwardedHost = context.Request.Headers["X-Forwarded-Host"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwardedHost))
+        {
+            return forwardedHost.Split(',')[0].Trim();
+        }
+
+        return context.Request.Host.Value ?? string.Empty;
     }
 
     private static bool IsValidSubdomain(string subdomain)

--- a/src/StudentRegistrar.Data/StudentRegistrarDbContext.cs
+++ b/src/StudentRegistrar.Data/StudentRegistrarDbContext.cs
@@ -432,80 +432,86 @@ public class StudentRegistrarDbContext : DbContext
         modelBuilder.Entity<AccountHolder>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Student>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Course>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Semester>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Enrollment>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Payment>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<CourseInstructor>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Educator>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<Room>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<GradeRecord>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<AcademicYear>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<User>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
         modelBuilder.Entity<UserProfile>()
             .HasQueryFilter(e =>
                 !_tenantProvider.ShouldApplyTenantFilter ||
-                (_tenantProvider.CurrentTenantId.HasValue &&
-                 e.TenantId == _tenantProvider.CurrentTenantId.Value));
+                e.TenantId == _tenantProvider.CurrentTenantId);
     }
 
     public override int SaveChanges()
     {
+        ApplyTenantIds();
         UpdateTimestamps();
         return base.SaveChanges();
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
+        ApplyTenantIds();
         UpdateTimestamps();
         return base.SaveChangesAsync(cancellationToken);
+    }
+
+    private void ApplyTenantIds()
+    {
+        if (!_tenantProvider.CurrentTenantId.HasValue)
+        {
+            return;
+        }
+
+        var currentTenantId = _tenantProvider.CurrentTenantId.Value;
+        var entries = ChangeTracker.Entries<ITenantEntity>()
+            .Where(entry => entry.State == EntityState.Added && entry.Entity.TenantId == Guid.Empty);
+
+        foreach (var entry in entries)
+        {
+            entry.Entity.TenantId = currentTenantId;
+        }
     }
 
     private void UpdateTimestamps()

--- a/tests/StudentRegistrar.E2E.Tests/Pages/SemestersPage.cs
+++ b/tests/StudentRegistrar.E2E.Tests/Pages/SemestersPage.cs
@@ -69,17 +69,10 @@ public class SemestersPage
         SemesterCodeInput.Clear();
         SemesterCodeInput.SendKeys(code);
         
-        StartDateInput.Clear();
-        StartDateInput.SendKeys(startDate.ToString("MM/dd/yyyy"));
-        
-        EndDateInput.Clear();
-        EndDateInput.SendKeys(endDate.ToString("MM/dd/yyyy"));
-
-        RegistrationStartDateInput.Clear();
-        RegistrationStartDateInput.SendKeys(regStartDate.ToString("MM/dd/yyyy"));
-
-        RegistrationEndDateInput.Clear();
-        RegistrationEndDateInput.SendKeys(regEndDate.ToString("MM/dd/yyyy"));
+        SetInputValue(StartDateInput, startDate.ToString("yyyy-MM-dd"));
+        SetInputValue(EndDateInput, endDate.ToString("yyyy-MM-dd"));
+        SetInputValue(RegistrationStartDateInput, regStartDate.ToString("yyyy-MM-dd"));
+        SetInputValue(RegistrationEndDateInput, regEndDate.ToString("yyyy-MM-dd"));
 
         if (isActive != IsActiveCheckbox.Selected)
         {
@@ -89,19 +82,12 @@ public class SemestersPage
 
     public void SaveSemester()
     {
-        SaveSemesterButton.Click();
-        
-        // Wait for error or modal close
-        // try {
-        //     _wait.Until(d => IsErrorDisplayed() || !SemesterModal.Displayed);
-        // } catch (WebDriverTimeoutException) {
-        //     // If neither error nor close, log and continue
-        //     Console.WriteLine("Timeout waiting for error or modal close after save");
-        // }
+        TryClickWithRetry(SaveSemesterButton);
+
         if (IsErrorDisplayed()) {
-            Console.WriteLine($"Error during save: {GetErrorMessage()}");
             return;
         }
+
         WaitForModalToClose();
     }
 
@@ -245,32 +231,21 @@ public class SemestersPage
 
     public void WaitForModalToClose()
     {
-        try
-        {
-            _wait.Until(d => {
-                try
-                {
-                    var modal = d.FindElement(By.Id("semester-modal"));
-                    return !modal.Displayed;
-                }
-                catch (NoSuchElementException)
-                {
-                    return true; // Modal is gone
-                }
-                catch (OpenQA.Selenium.StaleElementReferenceException)
-                {
-                    return true; // Modal element is stale, means it's been removed
-                }
-            });
-        }
-        catch (OpenQA.Selenium.WebDriverTimeoutException)
-        {
-            Console.WriteLine("Modal did not close within timeout period");
-            // Take a screenshot or log page source for debugging
-            Console.WriteLine($"Current URL: {_driver.Url}");
-            Console.WriteLine($"Page contains modal: {_driver.PageSource.Contains("semester-modal")}");
-            throw;
-        }
+        _wait.Until(d => {
+            try
+            {
+                var modal = d.FindElement(By.Id("semester-modal"));
+                return !modal.Displayed;
+            }
+            catch (NoSuchElementException)
+            {
+                return true;
+            }
+            catch (OpenQA.Selenium.StaleElementReferenceException)
+            {
+                return true;
+            }
+        });
     }
 
     // Helper methods
@@ -338,5 +313,19 @@ public class SemestersPage
             ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].scrollIntoView({block:'center'});", element);
             ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].click();", element);
         }
+    }
+
+    private void SetInputValue(IWebElement element, string value)
+    {
+        ((IJavaScriptExecutor)_driver).ExecuteScript(
+                        @"const input = arguments[0];
+                            const nextValue = arguments[1];
+                            const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), 'value')
+                                || Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+                            descriptor.set.call(input, nextValue);
+                            input.dispatchEvent(new Event('input', { bubbles: true }));
+                            input.dispatchEvent(new Event('change', { bubbles: true }));",
+            element,
+            value);
     }
 }

--- a/tests/StudentRegistrar.E2E.Tests/Tests/LoginTests.cs
+++ b/tests/StudentRegistrar.E2E.Tests/Tests/LoginTests.cs
@@ -50,6 +50,7 @@ public class LoginTests : BaseTest
     }
 
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Should_Login_Successfully_With_Valid_Credentials()
     {
         // Arrange

--- a/tests/StudentRegistrar.E2E.Tests/Tests/PublicCoursesTests.cs
+++ b/tests/StudentRegistrar.E2E.Tests/Tests/PublicCoursesTests.cs
@@ -11,6 +11,7 @@ namespace StudentRegistrar.E2E.Tests.Tests;
 public class PublicCoursesTests : BaseTest
 {
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Guest_Should_Access_Courses_Page_Without_Login()
     {
         // Arrange / Act - navigate directly to courses page

--- a/tests/StudentRegistrar.E2E.Tests/Tests/RoleBasedTests/AdminTests.cs
+++ b/tests/StudentRegistrar.E2E.Tests/Tests/RoleBasedTests/AdminTests.cs
@@ -10,6 +10,7 @@ namespace StudentRegistrar.E2E.Tests.Tests.RoleBasedTests;
 public class AdminTests : BaseTest
 {
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Admin_Should_Login_Successfully()
     {
         // Arrange
@@ -163,14 +164,6 @@ public class AdminTests : BaseTest
             var errorMatches = errorPattern.Matches(pageSource);
             var errorText = errorMatches.Count > 0 ? string.Join("; ", errorMatches.Take(3).Select(m => m.Value.Trim())) : "No specific errors found";
             
-            // Log the current state for debugging
-            Console.WriteLine($"DEBUG: Current URL: {currentUrl}");
-            Console.WriteLine($"DEBUG: Page Title: {pageTitle}");
-            Console.WriteLine($"DEBUG: {debugInfo}");
-            Console.WriteLine($"DEBUG: Error text: {errorText}");
-            Console.WriteLine($"DEBUG: Form still visible: {pageSource.Contains("submit-create-member")}");
-            Console.WriteLine($"DEBUG: Success message div exists: {pageSource.Contains("data-testid=\"success-message\"")}");
-            
             throw new Exception($"No success or error message appeared after member creation. Current URL: {currentUrl}, Page Title: {pageTitle}, Debug: {debugInfo}, Errors: {errorText}");
         }
     }
@@ -192,15 +185,17 @@ public class AdminTests : BaseTest
     // }
 
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Admin_Should_Access_Semester_Management()
     {
         // Arrange - Login as admin
         LoginAsAdmin();
 
         // Act - Navigate to semesters page
-        var semestersLink = Driver.FindElement(By.LinkText("Semesters"));
-        semestersLink.Click();
+        var navigationPage = new NavigationPage(Driver);
+        navigationPage.ClickSemesters();
         WaitForPageLoad();
+        WaitUntil(d => d.Url.Contains("/semesters") || d.PageSource.Contains("semester", StringComparison.OrdinalIgnoreCase));
 
         // Assert - Should be on semesters page
         Driver.Url.Should().Contain("/semesters", "Should navigate to semesters page");
@@ -448,7 +443,6 @@ public class AdminTests : BaseTest
         if (semestersPage.IsErrorDisplayed())
         {
             var errorMessage = semestersPage.GetErrorMessage();
-            Console.WriteLine($"Semester creation failed with error: {errorMessage}");
             
             // Cancel out of the modal and fail the test with a descriptive message
             semestersPage.CancelCreate();
@@ -999,6 +993,7 @@ public class AdminTests : BaseTest
     }
 
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Admin_Should_Create_New_Room_Successfully()
     {
         // Arrange
@@ -1010,7 +1005,7 @@ public class AdminTests : BaseTest
 
         // Act - Create a new room
         var createButton = Driver.FindElement(By.Id("create-room-btn"));
-    createButton.Click();
+        ClickWithOverlayFallback(createButton);
     WaitForPageLoad();
     WaitUntil(d => d.FindElements(By.Id("room-name-input")).Any());
 
@@ -1030,7 +1025,7 @@ public class AdminTests : BaseTest
 
         // Submit the form
         var saveButton = Driver.FindElement(By.Id("save-room-btn"));
-    saveButton.Click();
+        ClickWithOverlayFallback(saveButton);
     WaitForPageLoad();
     WaitUntil(d => d.PageSource.Contains(uniqueName));
 
@@ -1170,7 +1165,7 @@ public class AdminTests : BaseTest
     private void CreateTestRoom(string name, string roomType, int capacity, string notes)
     {
         var createButton = Driver.FindElement(By.Id("create-room-btn"));
-    createButton.Click();
+        ClickWithOverlayFallback(createButton);
     WaitForPageLoad();
     WaitUntil(d => d.FindElements(By.Id("room-name-input")).Any());
 
@@ -1191,9 +1186,30 @@ public class AdminTests : BaseTest
         }
 
         var saveButton = Driver.FindElement(By.Id("save-room-btn"));
-    saveButton.Click();
+        ClickWithOverlayFallback(saveButton);
     WaitForPageLoad();
     WaitUntil(d => d.PageSource.Contains(name));
+    }
+
+    private void ClickWithOverlayFallback(IWebElement element)
+    {
+        try
+        {
+            element.Click();
+        }
+        catch (ElementClickInterceptedException)
+        {
+            try
+            {
+                WaitUntil(d => !d.FindElements(By.CssSelector("nextjs-portal")).Any(portal => portal.Displayed), 5, 200);
+            }
+            catch
+            {
+            }
+
+            ((IJavaScriptExecutor)Driver).ExecuteScript("arguments[0].scrollIntoView({block:'center'});", element);
+            ((IJavaScriptExecutor)Driver).ExecuteScript("arguments[0].click();", element);
+        }
     }
 
     #endregion

--- a/tests/StudentRegistrar.E2E.Tests/Tests/RoleBasedTests/EducatorTests.cs
+++ b/tests/StudentRegistrar.E2E.Tests/Tests/RoleBasedTests/EducatorTests.cs
@@ -64,6 +64,7 @@ public class EducatorTests : BaseTest
     }
 
     [Fact]
+    [Trait("Suite", "SaaSCompatibility")]
     public void Educator_Should_Access_Educator_Section()
     {
         // Arrange - Login as educator


### PR DESCRIPTION
## Summary
- make tenant JWT validation issuer and signing key resolution realm-aware for SaaS tenant hosts
- respect forwarded host context through tenant resolution and the affected Next.js proxy routes
- fix tenant write stamping and semester/admin E2E stability so the SaaS compatibility slice can run against tenant subdomains

## Validation
- local SaaS compatibility slice against a provisioned tenant
- isolated `Admin_Should_Create_New_Semester_Successfully` SaaS compatibility run
